### PR TITLE
Update control.lua

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -33,8 +33,8 @@ script.on_event(defines.events.on_script_trigger_effect, function(event)
         force = entity.force_index,
         snap_to_grid = false,
         fast_replace = true,
-        player = entity.last_user,
-        character = entity.last_user and entity.last_user.character,
+--        player = entity.last_user,
+--        character = entity.last_user and entity.last_user.character,
         spill = false,
         raise_built = true,
     }


### PR DESCRIPTION
Commented out lines 36 and 37, as those were causing a bug when placing entities in map view, on other surfaces than where the player character currently was.  

I theorise this was due to the 'fast replace' emulation.  As far as I am aware fast replace can only happen in default view (ie: not map view) and some aspect of the emulated fast replace was trying to happen on the surface the player character was currently on instead.